### PR TITLE
add cdk typescript template

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -76,6 +76,9 @@ inquirer.prompt(questions).then((answers) => {
           case 'terraform':
              templateFileName = 'main.tf'
             break;
+            case 'cdk-typescript':
+              templateFileName = 'template.ts'
+             break;  
         default:
              templateFileName = 'template.yaml'
           break;

--- a/templates/nodejs16.x/cdk-typescript/template.ts
+++ b/templates/nodejs16.x/cdk-typescript/template.ts
@@ -1,0 +1,12 @@
+import {
+    aws_lambda as lambda,
+    Duration,
+  } from "aws-cdk-lib";
+
+  const myFunction = new lambda.Function(this, "MyFunction", {
+    runtime: lambda.Runtime.NODEJS_16_X,
+    timeout: Duration.seconds(3),
+    code: lambda.Code.fromAsset("projectName/function"),
+    handler: "app.lambdaHandler",
+    
+  });


### PR DESCRIPTION
- create cdk typescript template 
- update command/init.ts to point to `template.ts` file
- created a `cdk-typescript` folder to allow automatic folder detection. Another option would be to have `cdk` folder and a subfolder `typescript` but in this case the wizard needs to be modified to read the content of `cdk` folder. It's up to you how you want to keep it.